### PR TITLE
Fix compatibility with HA 2023.5.0 

### DIFF
--- a/custom_components/precoscombustiveis/__init__.py
+++ b/custom_components/precoscombustiveis/__init__.py
@@ -34,7 +34,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up the component from a config entry."""
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 


### PR DESCRIPTION
In 2023.5.0, the deprecated `async_setup_platforms` was removed. This Pull Request replaces the call with the recommended `async_forward_entry_setups`.

See for more details on this change in HA Core https://github.com/home-assistant/core/pull/91929