### PR TITLE
Fix SensorStateClass

### DIFF
--- a/custom_components/precoscombustiveis/sensor.py
+++ b/custom_components/precoscombustiveis/sensor.py
@@ -60,7 +60,7 @@ class PrecosCombustiveisSensor(SensorEntity):
         self._icon = DEFAULT_ICON
         self._unit_of_measurement = UNIT_OF_MEASUREMENT
         self._device_class = SensorDeviceClass.MONETARY
-        self._state_class = SensorStateClass.TOTAL
+        self._state_class = SensorStateClass.MEASUREMENT
         self._state = None
         self._available = True
 


### PR DESCRIPTION
Bug Fix

Using state_class total (`SensorStateClass.TOTAL`) makes the statistics incorrect, creating summation of values.
state_class measurement (`SensorStateClass.MEASUREMENT`) seems more correct for fuel prices, statistics will create mean, min and max