### PR TITLE
Remove explicit LOGGER.setLevel to avoid spamming home-assistant.log

### DIFF
--- a/custom_components/precoscombustiveis/__init__.py
+++ b/custom_components/precoscombustiveis/__init__.py
@@ -12,7 +12,6 @@ from .const import DOMAIN
 
 __version__ = "1.1.0"
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.setLevel(logging.DEBUG)
 
 PLATFORMS: list[str] = ["sensor"]
 

--- a/custom_components/precoscombustiveis/config_flow.py
+++ b/custom_components/precoscombustiveis/config_flow.py
@@ -12,7 +12,6 @@ from .dgeg import DGEG
 from .const import DOMAIN, CONF_STATIONID
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.setLevel(logging.DEBUG)
 
 DATA_SCHEMA = vol.Schema(
     { 

--- a/custom_components/precoscombustiveis/dgeg.py
+++ b/custom_components/precoscombustiveis/dgeg.py
@@ -9,7 +9,6 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.setLevel(logging.DEBUG)
 
 
 class Station:

--- a/custom_components/precoscombustiveis/sensor.py
+++ b/custom_components/precoscombustiveis/sensor.py
@@ -23,7 +23,6 @@ from .const import (
 from .dgeg import DGEG, Station
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.setLevel(logging.DEBUG)
 
 # Time between updating data from API
 SCAN_INTERVAL = timedelta(minutes=60)


### PR DESCRIPTION
This removes the explicit debug level and can be enabled (if required) by setting the following in homeassistant configuration

```
logger:
  logs:
    custom_components.precoscombustiveis.dgeg: debug
```